### PR TITLE
Wip custom func rendering

### DIFF
--- a/servant-jquery.cabal
+++ b/servant-jquery.cabal
@@ -30,7 +30,9 @@ flag example
 
 library
   exposed-modules:     Servant.JQuery
-  other-modules:       Servant.JQuery.Internal
+  other-modules:       Servant.JQuery.Functions
+                     , Servant.JQuery.Internal
+                     , Servant.JQuery.Types
   build-depends:       base >=4.5 && <5, servant >= 0.2.1, lens >= 4
   hs-source-dirs:      src
   default-language:    Haskell2010

--- a/src/Servant/JQuery.hs
+++ b/src/Servant/JQuery.hs
@@ -49,7 +49,6 @@ generateJS' settings req = renderFunctionWrap (_functionFormat settings)
              <> "    , type: '" <> method <> "'\n"
              <> "    });\n"
 
-        argsStr = intercalate ", " args
         args = captures
             ++ map (view argName) queryparams
             ++ body

--- a/src/Servant/JQuery.hs
+++ b/src/Servant/JQuery.hs
@@ -12,10 +12,12 @@
 module Servant.JQuery
   ( jquery
   , generateJS
+  , generateJS'
   , printJS
   , module Servant.JQuery.Internal
-  , Settings
-  , FunctionFormat
+  , Settings(..)
+  , FunctionFormat(..)
+  , defaultSettings
   ) where
 
 import Control.Lens

--- a/src/Servant/JQuery/Functions.hs
+++ b/src/Servant/JQuery/Functions.hs
@@ -45,7 +45,7 @@ hoistedF
 hoistedF fname margs middle = "\n"
     <> "function " <> fname
     <> "(" <> margs <> "){" <> "\n"
-    <> middle <> "}"
+    <> middle <> "}" <> "\n"
 
 -- | Render a non-hoisted function
 nonHoistedF
@@ -57,8 +57,8 @@ nonHoistedF
     -> String -- ^ Rendered JS non-hoisted function
 nonHoistedF mname fname margs middle = "\n"
     <> prefix <> fname <> " = function ("
-    <> margs <> "}{" <> "\n"
-    <> middle <> "};"
+    <> margs <> "){" <> "\n"
+    <> middle <> "};" <> "\n"
   where
     prefix = case mname of
         Just mn -> mn <> "."
@@ -72,7 +72,7 @@ anonF
     -> String -- ^ Rendered JS anonymous function
 anonF margs willReturn middle = "\n"
     <> returnOrNot
-    <> "function(" <> margs
+    <> "function (" <> margs
     <> "){" <> "\n"
     <> middle
     <> returnTrail <> "\n"

--- a/src/Servant/JQuery/Functions.hs
+++ b/src/Servant/JQuery/Functions.hs
@@ -1,0 +1,87 @@
+module Servant.JQuery.Functions (
+    renderFunctionWrap
+) where
+
+import Data.List
+import Data.Monoid
+import Servant.JQuery.Types
+
+-- | Renders a JS function wrapper
+renderFunctionWrap
+    :: FunctionFormat -- ^ Format of function
+    -> String -- ^ Function name
+    -> [String] -- ^ Function argument variable names
+    -> String -- ^ Function content
+    -> String -- ^ Rendered JS function
+renderFunctionWrap f n a m = show $ getFunctionWrap f n a (Right m)
+
+-- | Prepares a JS function wrapper
+getFunctionWrap
+    :: FunctionFormat -- ^ Format of function
+    -> String -- ^ Function name
+    -> [String] -- ^ Function argument variable names
+    -> Either JSFunction String -- ^ Function content
+    -> JSFunction -- ^ Prepared JS function
+getFunctionWrap Hoisted n a m     = HoistedFn n a m
+getFunctionWrap NonHoisted n a m  = NonHoistedFn n a Nothing m
+getFunctionWrap (Module mn) n a m = NonHoistedFn n a (Just mn) m
+getFunctionWrap PurescriptFriendly n [] m     = HoistedFn n [] m
+getFunctionWrap PurescriptFriendly n (a:[]) m = HoistedFn n [a] m
+getFunctionWrap PurescriptFriendly n a m = HoistedFn n a . Left $
+    getFunctionWrap (Anonymous True) "" [] m
+getFunctionWrap (Anonymous rt) _ a m = AnonymousFn a rt m
+
+instance Show JSFunction where
+    show (HoistedFn n a m)       = hoistedF n (argsStr a) (either show id m)
+    show (NonHoistedFn n a mn m) = nonHoistedF mn n (argsStr a) (either show id m)
+    show (AnonymousFn a rt m)    = anonF (argsStr a) rt (either show id m)
+
+-- | Renders a hoisted function
+hoistedF
+    :: String -- ^ Function name
+    -> String -- ^ Argument name/s
+    -> String -- ^ Function content
+    -> String -- ^ Rendered JS hoisted function
+hoistedF fname margs middle = "\n"
+    <> "function " <> fname
+    <> "(" <> margs <> "){" <> "\n"
+    <> middle <> "}"
+
+-- | Render a non-hoisted function
+nonHoistedF
+    :: Maybe String -- ^ Either a module name or a Nothing to specify
+                    -- we should use a var
+    -> String -- ^ Function name
+    -> String -- ^ Argument name/s
+    -> String -- ^ Function content
+    -> String -- ^ Rendered JS non-hoisted function
+nonHoistedF mname fname margs middle = "\n"
+    <> prefix <> fname <> " = function ("
+    <> margs <> "}{" <> "\n"
+    <> middle <> "};"
+  where
+    prefix = case mname of
+        Just mn -> mn <> "."
+        Nothing -> "var "
+
+-- | Renders an anonymous function
+anonF
+    :: String -- ^ Argument name/s
+    -> Bool -- ^ Whether the function should be returned as a variable
+    -> String -- ^ Function content
+    -> String -- ^ Rendered JS anonymous function
+anonF margs willReturn middle = "\n"
+    <> returnOrNot
+    <> "function(" <> margs
+    <> "){" <> "\n"
+    <> middle
+    <> returnTrail <> "\n"
+  where
+    returnOrNot = if willReturn then "return " else ""
+    returnTrail = if willReturn then "};" else "}"
+
+-- Turns argument names into a comma separated string
+argsStr
+    :: [String] -- ^ Argument variable names
+    -> String -- ^ Comma separated variable list
+argsStr = intercalate ","

--- a/src/Servant/JQuery/Types.hs
+++ b/src/Servant/JQuery/Types.hs
@@ -1,0 +1,31 @@
+module Servant.JQuery.Types where
+
+data Settings = Settings
+    { _functionFormat :: FunctionFormat
+    , _baseURI        :: String
+    }
+
+defaultSettings :: Settings
+defaultSettings = Settings Hoisted ""
+
+data FunctionFormat = Hoisted
+                    | NonHoisted
+                    | Module String
+                    | PurescriptFriendly
+                    | Anonymous Bool
+
+data JSFunction =
+    HoistedFn
+    { _funcName     :: String
+    , _funcArgs     :: [String]
+    , _funcContents :: Either JSFunction String
+    } | NonHoistedFn
+    { _funcName     :: String
+    , _funcArgs     :: [String]
+    , _funcModule   :: Maybe String
+    , _funcContents :: Either JSFunction String
+    } | AnonymousFn
+    { _funcArgs     :: [String]
+    , _funcReturned :: Bool
+    , _funcContents :: Either JSFunction String
+    }

--- a/test/Servant/JQuerySpec.hs
+++ b/test/Servant/JQuerySpec.hs
@@ -15,6 +15,7 @@ import Test.Hspec
 import Servant.API
 import Servant.JQuery
 import Servant.JQuerySpec.CustomHeaders
+import Servant.JQuerySpec.FunctionRender
 
 type TestAPI = [sitemap|
 POST    /simple                  String -> Bool
@@ -49,8 +50,9 @@ customHeaderProxy2 :: Proxy CustomHeaderAPI2
 customHeaderProxy2 = Proxy
 
 spec :: Spec
-spec = describe "Servant.JQuery"
-    generateJSSpec
+spec = do
+    describe "Servant.JQuery" generateJSSpec
+    describe "Servant.JQuery" renderFunctionJSSpec
 
 generateJSSpec :: Spec
 generateJSSpec = describe "generateJS" $ do

--- a/test/Servant/JQuerySpec/FunctionRender.hs
+++ b/test/Servant/JQuerySpec/FunctionRender.hs
@@ -1,0 +1,76 @@
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE FlexibleInstances   #-}
+{-# LANGUAGE QuasiQuotes         #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeFamilies        #-}
+{-# LANGUAGE TypeOperators       #-}
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+module Servant.JQuerySpec.FunctionRender where
+
+import Data.Either (isRight)
+import Data.List
+import Data.Proxy
+import Language.ECMAScript3.Parser (parseFromString)
+import Test.Hspec
+
+import Servant.API
+import Servant.JQuery
+
+data Book = Book String String
+
+type BookAPI = "books" :> Capture "isbn" String :> Get Book
+
+bookAPIProxy :: Proxy BookAPI
+bookAPIProxy = Proxy
+
+renderFunctionJSSpec :: Spec
+renderFunctionJSSpec = describe "JS function rendering" $ do
+    it "should generate valid javascript with default settings" $ do
+        let out = generateJS' defaultSettings $ jquery bookAPIProxy
+        print out
+        ("\nfunction getbooks(isbn,onSuccess,onError){" `isPrefixOf` out) `shouldBe` True
+        ("}\n" `isSuffixOf` out) `shouldBe` True
+        parseFromString out `shouldSatisfy` isRight
+
+    it "should generate valid javascript hoisted function" $ do
+        let out = generateJS' (Settings Hoisted "") $ jquery bookAPIProxy
+        print out
+        ("\nfunction getbooks(isbn,onSuccess,onError){" `isPrefixOf` out) `shouldBe` True
+        ("}\n" `isSuffixOf` out) `shouldBe` True
+        parseFromString out `shouldSatisfy` isRight
+
+    it "should generate valid javascript non-hoisted function" $ do
+        let out = generateJS' (Settings NonHoisted "") $ jquery bookAPIProxy
+        print out
+        ("\nvar getbooks = function (isbn,onSuccess,onError){" `isPrefixOf` out) `shouldBe` True
+        ("};\n" `isSuffixOf` out) `shouldBe` True
+        parseFromString out `shouldSatisfy` isRight
+
+    it "should generate valid javascript module function" $ do
+        let out = generateJS' (Settings (Module "Foo.Bar") "") $ jquery bookAPIProxy
+        print out
+        ("\nFoo.Bar.getbooks = function (isbn,onSuccess,onError){" `isPrefixOf` out) `shouldBe` True
+        ("};\n" `isSuffixOf` out) `shouldBe` True
+        parseFromString out `shouldSatisfy` isRight
+
+    it "should generate valid anonymous function" $ do
+        let out = generateJS' (Settings (Anonymous False) "") $ jquery bookAPIProxy
+        print out
+        ("\nfunction (isbn,onSuccess,onError){" `isPrefixOf` out) `shouldBe` True
+        ("}\n" `isSuffixOf` out) `shouldBe` True
+        parseFromString out `shouldSatisfy` isRight
+
+    it "should generate valid anonymous function variable" $ do
+        let out = generateJS' (Settings (Anonymous True) "") $ jquery bookAPIProxy
+        print out
+        ("\nreturn function (isbn,onSuccess,onError){" `isPrefixOf` out) `shouldBe` True
+        ("};\n" `isSuffixOf` out) `shouldBe` True
+        parseFromString out `shouldSatisfy` isRight
+
+    it "should generate valid purescript-friendly function" $ do
+        let out = generateJS' (Settings PurescriptFriendly "") $ jquery bookAPIProxy
+        print out
+        ("\nfunction getbooks(isbn,onSuccess,onError){\n\nreturn function (){\n" `isPrefixOf` out) `shouldBe` True
+        ("};\n}\n" `isSuffixOf` out) `shouldBe` True
+        parseFromString out `shouldSatisfy` isRight


### PR DESCRIPTION
(See also: https://github.com/haskell-servant/servant-jquery/pull/8)

This is intended to address #7 by creating a Settings data type which contains a FunctionFormat that dictates how the external wrapper function is rendered.

Currently, the FunctionFormats supported are as follows:

Hoisted
function foo(arg1, onSuccess, onError){ ... }
NonHoisted
var foo = function(arg1, onSuccess, onError){ ... };
Module (String - module name)
Hello.World.foo = function(arg1, onSuccess, onError){ ... };
PurescriptFriendly
function foo(arg1, onSuccess, onError){ return foo(){ ... }; }
Anonymous (Bool - return as a variable)
function(arg1, onSuccess, onError){ ... } or return function(arg1, onSuccess, onError){ ... };
Tests have been added for each one of these FunctionFormats to make sure they render as intended.

(The Settings type also contains a base URL which we don't use yet, but will eventually use to change the URL that the AJAX request is pointed at.)